### PR TITLE
initialize sentry when deployed to vercel only

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,40 +22,44 @@ module.exports = nextConfig;
 
 const { withSentryConfig } = require('@sentry/nextjs');
 
-module.exports = withSentryConfig(
-  module.exports,
-  {
-    // For all available options, see:
-    // https://github.com/getsentry/sentry-webpack-plugin#options
+// https://vercel.com/docs/projects/environment-variables/system-environment-variables#system-environment-variables
+// Initialize sentry when deployed to vercel only
+if (!!process.env.VERCEL_ENV) {
+  module.exports = withSentryConfig(
+    module.exports,
+    {
+      // For all available options, see:
+      // https://github.com/getsentry/sentry-webpack-plugin#options
 
-    // Suppresses source map uploading logs during build
-    silent: true,
-    org: 'nicholeuf',
-    project: 'javascript-nextjs',
-  },
-  {
-    // For all available options, see:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+      // Suppresses source map uploading logs during build
+      silent: true,
+      org: 'nicholeuf',
+      project: 'javascript-nextjs',
+    },
+    {
+      // For all available options, see:
+      // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 
-    // Upload a larger set of source maps for prettier stack traces (increases build time)
-    widenClientFileUpload: true,
+      // Upload a larger set of source maps for prettier stack traces (increases build time)
+      widenClientFileUpload: true,
 
-    // Transpiles SDK to be compatible with IE11 (increases bundle size)
-    transpileClientSDK: true,
+      // Transpiles SDK to be compatible with IE11 (increases bundle size)
+      transpileClientSDK: true,
 
-    // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers (increases server load)
-    tunnelRoute: '/monitoring',
+      // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers (increases server load)
+      tunnelRoute: '/monitoring',
 
-    // Hides source maps from generated client bundles
-    hideSourceMaps: false,
+      // Hides source maps from generated client bundles
+      hideSourceMaps: false,
 
-    // Automatically tree-shake Sentry logger statements to reduce bundle size
-    disableLogger: true,
+      // Automatically tree-shake Sentry logger statements to reduce bundle size
+      disableLogger: true,
 
-    // Enables automatic instrumentation of Vercel Cron Monitors.
-    // See the following for more information:
-    // https://docs.sentry.io/product/crons/
-    // https://vercel.com/docs/cron-jobs
-    automaticVercelMonitors: true,
-  }
-);
+      // Enables automatic instrumentation of Vercel Cron Monitors.
+      // See the following for more information:
+      // https://docs.sentry.io/product/crons/
+      // https://vercel.com/docs/cron-jobs
+      automaticVercelMonitors: true,
+    }
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -18,13 +18,13 @@ const nextConfig = {
 
 module.exports = nextConfig;
 
-// Injected content via Sentry wizard below
-
-const { withSentryConfig } = require('@sentry/nextjs');
-
 // https://vercel.com/docs/projects/environment-variables/system-environment-variables#system-environment-variables
 // Initialize sentry when deployed to vercel only
 if (!!process.env.VERCEL_ENV) {
+  // Injected content via Sentry wizard below
+
+  const { withSentryConfig } = require('@sentry/nextjs');
+
   module.exports = withSentryConfig(
     module.exports,
     {


### PR DESCRIPTION
I'm seeing errors from local development in sentry, which is noisy and unhelpful. Only initialize sentry on vercel deployments.