### PR TITLE
Refresh landing image and add a background image to the sparse contact page

### DIFF
--- a/src/app/__snapshots__/page.test.tsx.snap
+++ b/src/app/__snapshots__/page.test.tsx.snap
@@ -348,7 +348,7 @@ exports[`The Home Page has expected snapshot 1`] = `
 .emotion-2 {
   height: 100%;
   width: 100%;
-  background: url(https://res.cloudinary.com/nicholeuf/image/upload/o_30/f_auto/q_5/v1/zensite/scott-webb-5mIcH3q7tIk-unsplash?_a=BAVAfVBy0) no-repeat;
+  background: url(https://res.cloudinary.com/nicholeuf/image/upload/o_20/f_auto/q_5/v1/zensite/andrei-slobtsov-Med3Kuxz97c-unsplash?_a=BAVAfVBy0) no-repeat;
   -webkit-background-position: 50% 25%;
   background-position: 50% 25%;
   -webkit-background-size: cover;

--- a/src/app/__snapshots__/page.test.tsx.snap
+++ b/src/app/__snapshots__/page.test.tsx.snap
@@ -325,7 +325,6 @@ exports[`The Home Page has expected snapshot 1`] = `
 }
 
 .emotion-1 {
-  min-height: calc(100vh - 60px - 175px);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -341,7 +340,7 @@ exports[`The Home Page has expected snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  padding-left: 24px;
+  min-height: calc(100vh - 60px - 175px);
   position: relative;
 }
 
@@ -362,6 +361,7 @@ exports[`The Home Page has expected snapshot 1`] = `
 .emotion-3 {
   margin-top: 24px;
   margin-bottom: 24px;
+  padding-left: 24px;
   display: grid;
   gap: 16px;
 }

--- a/src/app/contact/ContactPage.tsx
+++ b/src/app/contact/ContactPage.tsx
@@ -1,10 +1,10 @@
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-import { Metadata } from 'next';
 
 import PageContainer from '@/components/PageContainer';
 import ExternalLink from '@/components/ExternalLink';
 import { SMALLCHAT_ENABLED } from '@/app/lib/smallchat';
+import BackgroundImage from '@/components/BackgroundImage';
 
 interface ContactPageProps {
   chatEnabled?: boolean;
@@ -39,12 +39,10 @@ const ContactPage: React.FC<ContactPageProps> = ({
 
   return (
     <PageContainer data-testid="contact-page">
-      <Box component="section">
-        <Typography variant="h1" gutterBottom>
-          Contact
-        </Typography>
-        {getCopy()}
-      </Box>
+      <Typography variant="h1" gutterBottom>
+        Contact
+      </Typography>
+      {getCopy()}
     </PageContainer>
   );
 };

--- a/src/app/contact/__snapshots__/ContactPage.test.tsx.snap
+++ b/src/app/contact/__snapshots__/ContactPage.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`The Contact Page Component has expected snapshot when chat enabled 1`] 
   }
 }
 
-.emotion-2 {
+.emotion-1 {
   margin: 0;
   font-family: fontFamily;
   font-weight: 300;
@@ -36,24 +36,24 @@ exports[`The Contact Page Component has expected snapshot when chat enabled 1`] 
 }
 
 @media (min-width:600px) {
-  .emotion-2 {
+  .emotion-1 {
     font-size: 4.7129rem;
   }
 }
 
 @media (min-width:900px) {
-  .emotion-2 {
+  .emotion-1 {
     font-size: 5.3556rem;
   }
 }
 
 @media (min-width:1200px) {
-  .emotion-2 {
+  .emotion-1 {
     font-size: 5.9983rem;
   }
 }
 
-.emotion-3 {
+.emotion-2 {
   margin: 0;
   font-size: 0.9rem;
   font-family: fontFamily;
@@ -61,7 +61,7 @@ exports[`The Contact Page Component has expected snapshot when chat enabled 1`] 
   line-height: 1.43;
 }
 
-.emotion-4 {
+.emotion-3 {
   margin: 0;
   font: inherit;
   color: #FA2742;
@@ -69,7 +69,7 @@ exports[`The Contact Page Component has expected snapshot when chat enabled 1`] 
   text-decoration: none;
 }
 
-.emotion-4:hover {
+.emotion-3:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -78,31 +78,27 @@ exports[`The Contact Page Component has expected snapshot when chat enabled 1`] 
   className="MuiContainer-root MuiContainer-maxWidthLg emotion-0"
   data-testid="contact-page"
 >
-  <section
-    className="MuiBox-root emotion-1"
+  <h1
+    className="MuiTypography-root MuiTypography-h1 MuiTypography-gutterBottom emotion-1"
   >
-    <h1
-      className="MuiTypography-root MuiTypography-h1 MuiTypography-gutterBottom emotion-2"
+    Contact
+  </h1>
+  <p
+    className="MuiTypography-root MuiTypography-body2 emotion-2"
+  >
+    Please connect with me on 
+    <a
+      className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-3"
+      href="https://www.linkedin.com/in/nicholeuf"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      rel="noopener"
+      target="_blank"
     >
-      Contact
-    </h1>
-    <p
-      className="MuiTypography-root MuiTypography-body2 emotion-3"
-    >
-      Please connect with me on 
-      <a
-        className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-4"
-        href="https://www.linkedin.com/in/nicholeuf"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        rel="noopener"
-        target="_blank"
-      >
-        LinkedIn
-      </a>
-       or send a message in chat. I look forward to hearing from you!
-    </p>
-  </section>
+      LinkedIn
+    </a>
+     or send a message in chat. I look forward to hearing from you!
+  </p>
 </div>
 `;
 
@@ -132,7 +128,7 @@ exports[`The Contact Page Component has expected snapshot when chat is not enabl
   }
 }
 
-.emotion-2 {
+.emotion-1 {
   margin: 0;
   font-family: fontFamily;
   font-weight: 300;
@@ -142,24 +138,24 @@ exports[`The Contact Page Component has expected snapshot when chat is not enabl
 }
 
 @media (min-width:600px) {
-  .emotion-2 {
+  .emotion-1 {
     font-size: 4.7129rem;
   }
 }
 
 @media (min-width:900px) {
-  .emotion-2 {
+  .emotion-1 {
     font-size: 5.3556rem;
   }
 }
 
 @media (min-width:1200px) {
-  .emotion-2 {
+  .emotion-1 {
     font-size: 5.9983rem;
   }
 }
 
-.emotion-3 {
+.emotion-2 {
   margin: 0;
   font-size: 0.9rem;
   font-family: fontFamily;
@@ -167,7 +163,7 @@ exports[`The Contact Page Component has expected snapshot when chat is not enabl
   line-height: 1.43;
 }
 
-.emotion-4 {
+.emotion-3 {
   margin: 0;
   font: inherit;
   color: #FA2742;
@@ -175,7 +171,7 @@ exports[`The Contact Page Component has expected snapshot when chat is not enabl
   text-decoration: none;
 }
 
-.emotion-4:hover {
+.emotion-3:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -184,30 +180,26 @@ exports[`The Contact Page Component has expected snapshot when chat is not enabl
   className="MuiContainer-root MuiContainer-maxWidthLg emotion-0"
   data-testid="contact-page"
 >
-  <section
-    className="MuiBox-root emotion-1"
+  <h1
+    className="MuiTypography-root MuiTypography-h1 MuiTypography-gutterBottom emotion-1"
   >
-    <h1
-      className="MuiTypography-root MuiTypography-h1 MuiTypography-gutterBottom emotion-2"
+    Contact
+  </h1>
+  <p
+    className="MuiTypography-root MuiTypography-body2 emotion-2"
+  >
+    Please connect with me on 
+    <a
+      className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-3"
+      href="https://www.linkedin.com/in/nicholeuf"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      rel="noopener"
+      target="_blank"
     >
-      Contact
-    </h1>
-    <p
-      className="MuiTypography-root MuiTypography-body2 emotion-3"
-    >
-      Please connect with me on 
-      <a
-        className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-4"
-        href="https://www.linkedin.com/in/nicholeuf"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        rel="noopener"
-        target="_blank"
-      >
-        LinkedIn
-      </a>
-      . I look forward to hearing from you!
-    </p>
-  </section>
+      LinkedIn
+    </a>
+    . I look forward to hearing from you!
+  </p>
 </div>
 `;

--- a/src/app/contact/__snapshots__/page.test.tsx.snap
+++ b/src/app/contact/__snapshots__/page.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`The Contact Page has expected snapshot 1`] = `
 .emotion-2 {
   height: 100%;
   width: 100%;
-  background: url(https://res.cloudinary.com/nicholeuf/image/upload/o_20/f_auto/q_5/v1/zensite/faria-anzum-ONK9IlKizS4-unsplash?_a=BAVAfVBy0) no-repeat;
+  background: url(https://res.cloudinary.com/nicholeuf/image/upload/,z_0.1/o_20/f_auto/q_5/v1/zensite/faria-anzum-ONK9IlKizS4-unsplash?_a=BAVAfVBy0) no-repeat;
   -webkit-background-position: 50% 80%;
   background-position: 50% 80%;
   -webkit-background-size: cover;

--- a/src/app/contact/__snapshots__/page.test.tsx.snap
+++ b/src/app/contact/__snapshots__/page.test.tsx.snap
@@ -325,6 +325,25 @@ exports[`The Contact Page has expected snapshot 1`] = `
 }
 
 .emotion-1 {
+  min-height: calc(100vh - 60px - 175px);
+  position: relative;
+}
+
+.emotion-2 {
+  height: 100%;
+  width: 100%;
+  background: url(https://res.cloudinary.com/nicholeuf/image/upload/o_20/f_auto/q_5/v1/zensite/faria-anzum-ONK9IlKizS4-unsplash?_a=BAVAfVBy0) no-repeat;
+  -webkit-background-position: 50% 80%;
+  background-position: 50% 80%;
+  -webkit-background-size: cover;
+  background-size: cover;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  z-index: -1;
+}
+
+.emotion-3 {
   width: 100%;
   margin-left: auto;
   box-sizing: border-box;
@@ -337,19 +356,19 @@ exports[`The Contact Page has expected snapshot 1`] = `
 }
 
 @media (min-width:600px) {
-  .emotion-1 {
+  .emotion-3 {
     padding-left: 24px;
     padding-right: 24px;
   }
 }
 
 @media (min-width:1200px) {
-  .emotion-1 {
+  .emotion-3 {
     max-width: 1200px;
   }
 }
 
-.emotion-3 {
+.emotion-4 {
   margin: 0;
   font-family: fontFamily;
   font-weight: 300;
@@ -359,24 +378,24 @@ exports[`The Contact Page has expected snapshot 1`] = `
 }
 
 @media (min-width:600px) {
-  .emotion-3 {
+  .emotion-4 {
     font-size: 4.7129rem;
   }
 }
 
 @media (min-width:900px) {
-  .emotion-3 {
+  .emotion-4 {
     font-size: 5.3556rem;
   }
 }
 
 @media (min-width:1200px) {
-  .emotion-3 {
+  .emotion-4 {
     font-size: 5.9983rem;
   }
 }
 
-.emotion-4 {
+.emotion-5 {
   margin: 0;
   font-size: 0.9rem;
   font-family: fontFamily;
@@ -384,7 +403,7 @@ exports[`The Contact Page has expected snapshot 1`] = `
   line-height: 1.43;
 }
 
-.emotion-5 {
+.emotion-6 {
   margin: 0;
   font: inherit;
   color: #FA2742;
@@ -392,7 +411,7 @@ exports[`The Contact Page has expected snapshot 1`] = `
   text-decoration: none;
 }
 
-.emotion-5:hover {
+.emotion-6:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -401,23 +420,28 @@ exports[`The Contact Page has expected snapshot 1`] = `
     className="MuiContainer-root MuiContainer-maxWidthLg emotion-0"
   >
     <div
-      className="MuiContainer-root MuiContainer-maxWidthLg emotion-1"
-      data-testid="contact-page"
+      className="MuiBox-root emotion-1"
+      data-testid="contact-background-wrapper"
     >
-      <section
+      <div
         className="MuiBox-root emotion-2"
+        data-testid="contact-background-image"
+      />
+      <div
+        className="MuiContainer-root MuiContainer-maxWidthLg emotion-3"
+        data-testid="contact-page"
       >
         <h1
-          className="MuiTypography-root MuiTypography-h1 MuiTypography-gutterBottom emotion-3"
+          className="MuiTypography-root MuiTypography-h1 MuiTypography-gutterBottom emotion-4"
         >
           Contact
         </h1>
         <p
-          className="MuiTypography-root MuiTypography-body2 emotion-4"
+          className="MuiTypography-root MuiTypography-body2 emotion-5"
         >
           Please connect with me on 
           <a
-            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-5"
+            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
             href="https://www.linkedin.com/in/nicholeuf"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -428,7 +452,7 @@ exports[`The Contact Page has expected snapshot 1`] = `
           </a>
           . I look forward to hearing from you!
         </p>
-      </section>
+      </div>
     </div>
   </main>,
   .emotion-0 {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,13 +1,33 @@
 import { Metadata } from 'next';
 
 import ContactPage from './ContactPage';
+import BackgroundImage from '@/components/BackgroundImage';
 
 export const metadata: Metadata = {
   title: 'Contact',
 };
 
 const Contact: React.FC = () => {
-  return <ContactPage />;
+  return (
+    <BackgroundImage
+      wrapperTestId="contact-background-wrapper"
+      imageTestId="contact-background-image"
+      cldImageProps={{
+        // getCldImageUrl uses the same API as CldImage and sizes
+        // They're both wrappers around @cloudinary-util/url-loader which provide a simpler way to generate images and Cloudinary URLs.
+        // https://next.cloudinary.dev/getcldimageurl/basic-usage#basic-usage
+        // @ts-ignore
+        sizes: '100vw',
+        opacity: '20',
+        src: 'zensite/faria-anzum-ONK9IlKizS4-unsplash',
+        aspectRatio: '2:3',
+        quality: '5',
+      }}
+      backgroundPosition="50% 80%"
+    >
+      <ContactPage />
+    </BackgroundImage>
+  );
 };
 
 export default Contact;

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -22,6 +22,7 @@ const Contact: React.FC = () => {
         src: 'zensite/faria-anzum-ONK9IlKizS4-unsplash',
         aspectRatio: '2:3',
         quality: '5',
+        zoom: '0.1',
       }}
       backgroundPosition="50% 80%"
     >

--- a/src/components/BackgroundImage.tsx
+++ b/src/components/BackgroundImage.tsx
@@ -8,27 +8,33 @@ import React from 'react';
 
 interface BackgroundImageProps {
   cldImageProps: GetCldImageUrlOptions;
+  backgroundPosition?: string;
   wrapperTestId: string;
   imageTestId: string;
+  centerContent: boolean;
   children: React.ReactNode;
 }
 
 const BackgroundImage: React.FC<BackgroundImageProps> = ({
   cldImageProps,
+  backgroundPosition,
   wrapperTestId,
   imageTestId,
+  centerContent,
   children,
 }) => {
+  const centerSx = {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  };
   return (
     <Box
       data-testid={wrapperTestId}
       sx={{
+        ...(centerContent && centerSx),
         minHeight: getMainHeight(),
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignItems: 'center',
-        pl: 3,
         position: 'relative',
       }}
     >
@@ -38,7 +44,7 @@ const BackgroundImage: React.FC<BackgroundImageProps> = ({
           height: '100%',
           width: '100%',
           background: `url(${getCldImageUrl(cldImageProps)}) no-repeat`,
-          backgroundPosition: '50% 25%',
+          backgroundPosition,
           backgroundSize: 'cover',
           position: 'absolute',
           bottom: 0,

--- a/src/components/BackgroundImage.tsx
+++ b/src/components/BackgroundImage.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import { getCldImageUrl, GetCldImageUrlOptions } from 'next-cloudinary';
+
+import { getMainHeight } from '@/app/styles/styleUtils';
+import React from 'react';
+
+interface BackgroundImageProps {
+  cldImageProps: GetCldImageUrlOptions;
+  wrapperTestId: string;
+  imageTestId: string;
+  children: React.ReactNode;
+}
+
+const BackgroundImage: React.FC<BackgroundImageProps> = ({
+  cldImageProps,
+  wrapperTestId,
+  imageTestId,
+  children,
+}) => {
+  return (
+    <Box
+      data-testid={wrapperTestId}
+      sx={{
+        minHeight: getMainHeight(),
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        pl: 3,
+        position: 'relative',
+      }}
+    >
+      <Box
+        data-testid={imageTestId}
+        sx={{
+          height: '100%',
+          width: '100%',
+          background: `url(${getCldImageUrl(cldImageProps)}) no-repeat`,
+          backgroundPosition: '50% 25%',
+          backgroundSize: 'cover',
+          position: 'absolute',
+          bottom: 0,
+          right: 0,
+          zIndex: -1,
+        }}
+      ></Box>
+      {children}
+    </Box>
+  );
+};
+
+export default BackgroundImage;

--- a/src/components/CreditsModal/Credits.tsx
+++ b/src/components/CreditsModal/Credits.tsx
@@ -32,11 +32,11 @@ const Credits: React.FC<CreditsProps> = ({ titleId, descriptionId }) => {
         <DashListItem>
           <Typography>
             Home page background: Photo by&nbsp;
-            <ExternalLink href="https://unsplash.com/@scottwebb?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">
-              Scott Webb
+            <ExternalLink href="https://unsplash.com/@andreislobtsov?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">
+              Andrei Slobtsov
             </ExternalLink>
-            &nbsp;on&nbsp;
-            <ExternalLink href="https://unsplash.com/photos/rubber-plant-5mIcH3q7tIk?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">
+            &nbsp; on&nbsp;
+            <ExternalLink href="https://unsplash.com/photos/green-leaves-painting-Med3Kuxz97c?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">
               Unsplash
             </ExternalLink>
           </Typography>

--- a/src/components/CreditsModal/Credits.tsx
+++ b/src/components/CreditsModal/Credits.tsx
@@ -41,6 +41,18 @@ const Credits: React.FC<CreditsProps> = ({ titleId, descriptionId }) => {
             </ExternalLink>
           </Typography>
         </DashListItem>
+        <DashListItem>
+          <Typography>
+            Contact page background: Photo by&nbsp;
+            <ExternalLink href="https://unsplash.com/@farianzum?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">
+              Faria Anzum
+            </ExternalLink>
+            &nbsp; on&nbsp;
+            <ExternalLink href="https://unsplash.com/photos/green-succulent-on-white-and-pink-pot-ONK9IlKizS4?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">
+              Unsplash
+            </ExternalLink>
+          </Typography>
+        </DashListItem>
       </List>
     </>
   );

--- a/src/components/LandingPage/Content.tsx
+++ b/src/components/LandingPage/Content.tsx
@@ -17,6 +17,7 @@ const Content = () => {
     <Box
       sx={{
         my: 3,
+        pl: 3,
         display: 'grid',
         gap: 2,
         gridTemplateAreas: {

--- a/src/components/LandingPage/index.tsx
+++ b/src/components/LandingPage/index.tsx
@@ -25,6 +25,8 @@ const LandingPage: React.FC = () => {
         aspectRatio: '2:3',
         quality: '5',
       }}
+      backgroundPosition="50% 25%"
+      centerContent
     >
       <Content />
     </BackgroundImage>

--- a/src/components/LandingPage/index.tsx
+++ b/src/components/LandingPage/index.tsx
@@ -1,59 +1,33 @@
 'use client';
 
 import { Metadata } from 'next';
-import Box from '@mui/material/Box';
-import { getCldImageUrl } from 'next-cloudinary';
 
 import Content from './Content';
-import { getMainHeight } from '@/app/styles/styleUtils';
+import BackgroundImage from '@/components/BackgroundImage';
 
 export const metadata: Metadata = {
   title: "Nichole Frey's Portfolio",
 };
 
 const LandingPage: React.FC = () => {
-  // Generate responsive url to use as a background image
-  // Otherwise a width is required
-  const url = getCldImageUrl({
-    // getCldImageUrl uses the same API as CldImage and sizes
-    // They're both wrappers around @cloudinary-util/url-loader which provide a simpler way to generate images and Cloudinary URLs.
-    // https://next.cloudinary.dev/getcldimageurl/basic-usage#basic-usage
-    // @ts-ignore
-    sizes: '100vw',
-    opacity: '30',
-    src: 'zensite/scott-webb-5mIcH3q7tIk-unsplash',
-    aspectRatio: '2:3',
-    quality: '5',
-  });
   return (
-    <Box
-      data-testid="landing"
-      sx={{
-        minHeight: getMainHeight(),
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignItems: 'center',
-        pl: 3,
-        position: 'relative',
+    <BackgroundImage
+      wrapperTestId="landing"
+      imageTestId="landing-background-image"
+      cldImageProps={{
+        // getCldImageUrl uses the same API as CldImage and sizes
+        // They're both wrappers around @cloudinary-util/url-loader which provide a simpler way to generate images and Cloudinary URLs.
+        // https://next.cloudinary.dev/getcldimageurl/basic-usage#basic-usage
+        // @ts-ignore
+        sizes: '100vw',
+        opacity: '20',
+        src: 'zensite/andrei-slobtsov-Med3Kuxz97c-unsplash',
+        aspectRatio: '2:3',
+        quality: '5',
       }}
     >
-      <Box
-        data-testid="landing-background-image"
-        sx={{
-          height: '100%',
-          width: '100%',
-          background: `url(${url}) no-repeat`,
-          backgroundPosition: '50% 25%',
-          backgroundSize: 'cover',
-          position: 'absolute',
-          bottom: 0,
-          right: 0,
-          zIndex: -1,
-        }}
-      ></Box>
       <Content />
-    </Box>
+    </BackgroundImage>
   );
 };
 


### PR DESCRIPTION
I'm tired of looking at the landing background and the contact page is sparse. Let's go with something with more interest. 

## Landing Page
### Original
<img width="597" alt="Screenshot 2024-02-27 at 12 14 12 PM" src="https://github.com/nicholeuf/zen-site-next/assets/16197461/8f71ec70-7fef-4a7a-8e7b-7ac103f416d8">


### New
<img width="610" alt="Screenshot 2024-02-27 at 12 13 59 PM" src="https://github.com/nicholeuf/zen-site-next/assets/16197461/bac9f921-0147-4c72-bd5f-b94b4b2d882d">

## Contact Page
## Original
<img width="615" alt="Screenshot 2024-02-27 at 5 00 03 PM" src="https://github.com/nicholeuf/zen-site-next/assets/16197461/e09b9ea3-a9b9-48e9-9b18-b5244ccbd9df">

## New

<img width="595" alt="Screenshot 2024-02-27 at 5 00 10 PM" src="https://github.com/nicholeuf/zen-site-next/assets/16197461/36204579-ab28-4c97-a6ed-c1128b50a97f">
