### PR TITLE
NextLink workaround for not-found page

### DIFF
--- a/src/app/__snapshots__/loading.test.tsx.snap
+++ b/src/app/__snapshots__/loading.test.tsx.snap
@@ -209,6 +209,35 @@ exports[`The Loading Page has expected snapshot 1`] = `
   text-decoration: none;
 }
 
+.emotion-10 {
+  margin: 0;
+  font: inherit;
+  color: #FA2742;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  box-sizing: border-box;
+  letter-spacing: 1.25px;
+  height: 100%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #373833;
+  border-bottom: 4px solid;
+  border-bottom-color: rgb(251, 82, 103);
+  -webkit-transition: color 0.25s ease;
+  transition: color 0.25s ease;
+}
+
+.emotion-10:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-10:hover {
+  color: rgb(251, 82, 103);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <header
     className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed emotion-0"
     data-testid="header"
@@ -278,7 +307,8 @@ exports[`The Loading Page has expected snapshot 1`] = `
           disabled={false}
         >
           <a
-            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
+            aria-current="page"
+            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-10"
             href="/contact"
             onBlur={[Function]}
             onClick={[Function]}

--- a/src/app/__snapshots__/not-found.test.tsx.snap
+++ b/src/app/__snapshots__/not-found.test.tsx.snap
@@ -221,10 +221,7 @@ exports[`The Not Found (404) Page has expected snapshot 1`] = `
         className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-2"
         href="/"
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
-        onMouseEnter={[Function]}
-        onTouchStart={[Function]}
       >
         <span
           className="MuiBox-root emotion-3"
@@ -249,10 +246,7 @@ exports[`The Not Found (404) Page has expected snapshot 1`] = `
             className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
             href="/work"
             onBlur={[Function]}
-            onClick={[Function]}
             onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onTouchStart={[Function]}
           >
             Work
           </a>
@@ -265,10 +259,7 @@ exports[`The Not Found (404) Page has expected snapshot 1`] = `
             className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
             href="/about"
             onBlur={[Function]}
-            onClick={[Function]}
             onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onTouchStart={[Function]}
           >
             About
           </a>
@@ -281,10 +272,7 @@ exports[`The Not Found (404) Page has expected snapshot 1`] = `
             className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
             href="/contact"
             onBlur={[Function]}
-            onClick={[Function]}
             onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onTouchStart={[Function]}
           >
             Contact
           </a>
@@ -297,10 +285,7 @@ exports[`The Not Found (404) Page has expected snapshot 1`] = `
             className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
             href="/"
             onBlur={[Function]}
-            onClick={[Function]}
             onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onTouchStart={[Function]}
           >
             Home
           </a>

--- a/src/app/__snapshots__/page.test.tsx.snap
+++ b/src/app/__snapshots__/page.test.tsx.snap
@@ -209,6 +209,35 @@ exports[`The Home Page has expected snapshot 1`] = `
   text-decoration: none;
 }
 
+.emotion-12 {
+  margin: 0;
+  font: inherit;
+  color: #FA2742;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  box-sizing: border-box;
+  letter-spacing: 1.25px;
+  height: 100%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #373833;
+  border-bottom: 4px solid;
+  border-bottom-color: rgb(251, 82, 103);
+  -webkit-transition: color 0.25s ease;
+  transition: color 0.25s ease;
+}
+
+.emotion-12:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-12:hover {
+  color: rgb(251, 82, 103);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <header
     className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed emotion-0"
     data-testid="header"
@@ -294,7 +323,8 @@ exports[`The Home Page has expected snapshot 1`] = `
           disabled={false}
         >
           <a
-            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
+            aria-current="page"
+            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-12"
             href="/"
             onBlur={[Function]}
             onClick={[Function]}

--- a/src/app/about/__snapshots__/page.test.tsx.snap
+++ b/src/app/about/__snapshots__/page.test.tsx.snap
@@ -209,6 +209,35 @@ exports[`The About Page has expected snapshot 1`] = `
   text-decoration: none;
 }
 
+.emotion-8 {
+  margin: 0;
+  font: inherit;
+  color: #FA2742;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  box-sizing: border-box;
+  letter-spacing: 1.25px;
+  height: 100%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #373833;
+  border-bottom: 4px solid;
+  border-bottom-color: rgb(251, 82, 103);
+  -webkit-transition: color 0.25s ease;
+  transition: color 0.25s ease;
+}
+
+.emotion-8:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-8:hover {
+  color: rgb(251, 82, 103);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <header
     className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed emotion-0"
     data-testid="header"
@@ -262,7 +291,8 @@ exports[`The About Page has expected snapshot 1`] = `
           disabled={false}
         >
           <a
-            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
+            aria-current="page"
+            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-8"
             href="/about"
             onBlur={[Function]}
             onClick={[Function]}

--- a/src/app/about/page.test.tsx
+++ b/src/app/about/page.test.tsx
@@ -10,11 +10,20 @@ import {
   XS_DEVICE,
   SM_DEVICE,
 } from 'test-utils';
-
 import AboutPage from './page';
+
+const mockUsePathname = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  usePathname() {
+    return mockUsePathname();
+  },
+}));
 
 describe('The About Page', () => {
   beforeAll(() => {
+    mockUsePathname.mockImplementation(() => '/about');
+
     resetMatchMedia();
   });
 

--- a/src/app/contact/ContactPage.test.tsx
+++ b/src/app/contact/ContactPage.test.tsx
@@ -5,7 +5,19 @@ import { render, screen } from 'test-utils';
 
 import ContactPage from './ContactPage';
 
+const mockUsePathname = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  usePathname() {
+    return mockUsePathname();
+  },
+}));
+
 describe('The Contact Page Component', () => {
+  beforeAll(() => {
+    mockUsePathname.mockImplementation(() => '/contact');
+  });
+
   test('has expected content when chat enabled', () => {
     render(<ContactPage chatEnabled />);
 

--- a/src/app/contact/__snapshots__/page.test.tsx.snap
+++ b/src/app/contact/__snapshots__/page.test.tsx.snap
@@ -209,6 +209,35 @@ exports[`The Contact Page has expected snapshot 1`] = `
   text-decoration: none;
 }
 
+.emotion-10 {
+  margin: 0;
+  font: inherit;
+  color: #FA2742;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  box-sizing: border-box;
+  letter-spacing: 1.25px;
+  height: 100%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #373833;
+  border-bottom: 4px solid;
+  border-bottom-color: rgb(251, 82, 103);
+  -webkit-transition: color 0.25s ease;
+  transition: color 0.25s ease;
+}
+
+.emotion-10:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-10:hover {
+  color: rgb(251, 82, 103);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <header
     className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed emotion-0"
     data-testid="header"
@@ -278,7 +307,8 @@ exports[`The Contact Page has expected snapshot 1`] = `
           disabled={false}
         >
           <a
-            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
+            aria-current="page"
+            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-10"
             href="/contact"
             onBlur={[Function]}
             onClick={[Function]}

--- a/src/app/contact/page.test.tsx
+++ b/src/app/contact/page.test.tsx
@@ -12,8 +12,17 @@ import {
 
 import ContactPage from './page';
 
+const mockUsePathname = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  usePathname() {
+    return mockUsePathname();
+  },
+}));
+
 describe('The Contact Page', () => {
   beforeAll(() => {
+    mockUsePathname.mockImplementation(() => '/contact');
     resetMatchMedia();
   });
 

--- a/src/app/lib/routes.ts
+++ b/src/app/lib/routes.ts
@@ -21,4 +21,6 @@ const routes = {
   },
 };
 
+export const URLS = Object.values(routes).map((route) => route.href);
+
 export default routes;

--- a/src/app/loading.test.tsx
+++ b/src/app/loading.test.tsx
@@ -5,7 +5,19 @@ import { renderSnapshotWithLayout } from 'test-utils';
 
 import Loading from './loading';
 
+const mockUsePathname = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  usePathname() {
+    return mockUsePathname();
+  },
+}));
+
 describe('The Loading Page', () => {
+  beforeAll(() => {
+    mockUsePathname.mockImplementation(() => '/contact');
+  });
+
   test('has expected snapshot', () => {
     const component = renderSnapshotWithLayout(<Loading />);
     const tree = component.toJSON();

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -14,10 +14,6 @@ import userEvent from '@testing-library/user-event';
 
 const mockUsePathname = jest.fn();
 
-// Navigation accessibility resource
-// http://web-accessibility.carnegiemuseums.org/code/navigation/
-// https://www.erwinhofman.com/blog/build-web-accessible-hamburger-dropdown-menus/
-
 jest.mock('next/navigation', () => ({
   usePathname() {
     return mockUsePathname();
@@ -28,6 +24,7 @@ import HomePage from './page';
 
 describe('The Home Page', () => {
   beforeAll(() => {
+    mockUsePathname.mockImplementation(() => '/');
     resetMatchMedia();
   });
 
@@ -54,7 +51,6 @@ describe('The Home Page', () => {
 
     test('can interact with navigation', async () => {
       // mock usePathname to return the home page route
-      mockUsePathname.mockImplementation(() => '/');
 
       renderWithLayout(<HomePage />);
 
@@ -88,9 +84,6 @@ describe('The Home Page', () => {
     });
 
     test('can interact with mobile navigation', async () => {
-      // mock usePathname to return the home page route
-      mockUsePathname.mockImplementation(() => '/');
-
       renderWithLayout(<HomePage />);
 
       const user = userEvent.setup();

--- a/src/app/work/__snapshots__/page.test.tsx.snap
+++ b/src/app/work/__snapshots__/page.test.tsx.snap
@@ -194,6 +194,8 @@ exports[`The Work Page has expected snapshot 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #373833;
+  border-bottom: 4px solid;
+  border-bottom-color: rgb(251, 82, 103);
   -webkit-transition: color 0.25s ease;
   transition: color 0.25s ease;
 }
@@ -204,6 +206,33 @@ exports[`The Work Page has expected snapshot 1`] = `
 }
 
 .emotion-6:hover {
+  color: rgb(251, 82, 103);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-8 {
+  margin: 0;
+  font: inherit;
+  color: #FA2742;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  box-sizing: border-box;
+  letter-spacing: 1.25px;
+  height: 100%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #373833;
+  -webkit-transition: color 0.25s ease;
+  transition: color 0.25s ease;
+}
+
+.emotion-8:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-8:hover {
   color: rgb(251, 82, 103);
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -246,6 +275,7 @@ exports[`The Work Page has expected snapshot 1`] = `
           disabled={false}
         >
           <a
+            aria-current="page"
             className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
             href="/work"
             onBlur={[Function]}
@@ -262,7 +292,7 @@ exports[`The Work Page has expected snapshot 1`] = `
           disabled={false}
         >
           <a
-            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
+            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-8"
             href="/about"
             onBlur={[Function]}
             onClick={[Function]}
@@ -278,7 +308,7 @@ exports[`The Work Page has expected snapshot 1`] = `
           disabled={false}
         >
           <a
-            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
+            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-8"
             href="/contact"
             onBlur={[Function]}
             onClick={[Function]}
@@ -294,7 +324,7 @@ exports[`The Work Page has expected snapshot 1`] = `
           disabled={false}
         >
           <a
-            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-6"
+            className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover emotion-8"
             href="/"
             onBlur={[Function]}
             onClick={[Function]}

--- a/src/app/work/page.test.tsx
+++ b/src/app/work/page.test.tsx
@@ -11,6 +11,14 @@ import {
 
 import WorkPage from './page';
 
+const mockUsePathname = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  usePathname() {
+    return mockUsePathname();
+  },
+}));
+
 // Test TODO
 // Work header nav element is underlined
 // h1 is correct
@@ -18,6 +26,10 @@ import WorkPage from './page';
 // keyboard events work
 
 describe('The Work Page', () => {
+  beforeAll(() => {
+    mockUsePathname.mockImplementation(() => '/work');
+  });
+
   test('has expected snapshot', () => {
     const component = renderSnapshotWithLayout(<WorkPage />);
     const tree = component.toJSON();

--- a/src/components/NextLink.tsx
+++ b/src/components/NextLink.tsx
@@ -1,13 +1,23 @@
+'use client';
+
 import Link, { LinkProps } from '@mui/material/Link';
 import NLink from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { URLS } from '@/app/lib/routes';
 
 interface NextLinkProps extends LinkProps {
   children: React.ReactNode;
 }
 
 const NextLink: React.FC<NextLinkProps> = ({ children, ...props }) => {
+  // Workaround for https://github.com/nicholeuf/zen-site-next/issues/66
+  // Use anchor tag for all links on the "not found" page
+  const pathname = usePathname();
+  const isDefinedPath = URLS.includes(pathname);
+
   return (
-    <Link component={NLink} {...props}>
+    <Link component={isDefinedPath ? NLink : 'a'} {...props}>
       {children}
     </Link>
   );

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -3,9 +3,9 @@ import Typography from '@mui/material/Typography';
 import { usePathname } from 'next/navigation';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { Theme } from '@mui/material/styles';
-import Link from '@mui/material/Link';
 
 import ImageTemplate from '@/components/ImageTemplate';
+import NextLink from './NextLink';
 
 const WIDTH = 367;
 const HEIGHT = 261;
@@ -47,7 +47,7 @@ const NotFound = () => {
       <Typography data-testid="not-found-copy">
         The page <strong>{pathname}</strong> could not be found. Would you like
         to go to the&nbsp;
-        <Link href="/">Home Page</Link>?
+        <NextLink href="/">Home Page</NextLink>?
       </Typography>
     </ImageTemplate>
   );


### PR DESCRIPTION
NextLink returns an 'a' tag if on an unknown route (the not-found component will be displayed)

Resolves #66 (via workaround)