### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,4 +1,6 @@
 name: zen-site-next CI
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/nicholeuf/zen-site-next/security/code-scanning/1](https://github.com/nicholeuf/zen-site-next/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, installs dependencies, runs tests, and uploads coverage/test results (with no evidence of needing write access to repository contents or pull requests), the minimal permission required is likely `contents: read`. This should be added at the top level of the workflow file (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
