### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -1,4 +1,7 @@
 name: Manual Update pnpm Dependencies and Snapshots
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/nicholeuf/zen-site-next/security/code-scanning/2](https://github.com/nicholeuf/zen-site-next/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow at the top level or within the job. This block should grant only the minimum privileges necessary. For this workflow, the job primarily needs to:
- Check out code (requires `contents: read`).
- Create a pull request (which is handled by a PAT, not GITHUB_TOKEN, but it's best-practice to give explicit, minimal write access to `pull-requests` should GITHUB_TOKEN be used).
Set the following permissions either at the workflow level (global; applies to all jobs), or at the job level (for `update-dep`). The recommended minimal block is:
```yaml
permissions:
  contents: read
  pull-requests: write
```
Add this block immediately after the workflow name or at the job level. In this case, add it after line 1 (under `name:` and before `on:`) to scope it globally; this is most future-proof unless you have jobs needing different permissions.

No new imports or definitions are required for this YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
